### PR TITLE
Fix all-models-failed error and PDF render crash in dev mode

### DIFF
--- a/R/run_models.R
+++ b/R/run_models.R
@@ -42,7 +42,7 @@ run_models <- function(df) {
   # retentie must be a factor for tidymodels classification (glmnet fails on integer/character)
   # Normalize to character "0"/"1" first to handle logical/integer/character input
   df$retentie <- factor(
-    dplyr::if_else(as.numeric(df$retentie) == 0, "0", "1"),
+    dplyr::if_else(as.numeric(as.character(df$retentie)) == 0, "0", "1"),
     levels = c("0", "1")
   )
 
@@ -56,7 +56,7 @@ run_models <- function(df) {
   df_train      <- rsample::training(splits)
   df_test       <- rsample::testing(splits)
   df_validation <- rsample::validation_set(splits)
-  
+
   # Create a resample set based on 10 folds (default)
   df_resamples  <- rsample::vfold_cv(df_train, strata = retentie)
 

--- a/inst/templates/render_pdf.qmd
+++ b/inst/templates/render_pdf.qmd
@@ -426,7 +426,8 @@ if (file.exists(metadata_file)) {
   cat("- Model AUC:", round(metadata$model_auc, 4), "\n")
   cat("- Bias detectie-bereik: ratio < 0.8 of > 1.25\n")
   cat("- Onderzochte variabelen:", paste(names(conclusions_list), collapse = ", "), "\n")
-  cat("- R package versie: nfwa", as.character(packageVersion("nfwa")), "\n")
+  nfwa_version <- tryCatch(as.character(packageVersion("nfwa")), error = function(e) "dev")
+  cat("- R package versie: nfwa", nfwa_version, "\n")
 
   # Display EOI if available from metadata
   if (!is.null(metadata$eoi)) {
@@ -436,6 +437,7 @@ if (file.exists(metadata_file)) {
   cat("**Analyse-parameters:**\n\n")
   cat("- Datum analyse:", format(Sys.Date(), "%d-%m-%Y"), "\n")
   cat("- Onderzochte variabelen:", paste(names(conclusions_list), collapse = ", "), "\n")
-  cat("- R package versie: nfwa", as.character(packageVersion("nfwa")), "\n")
+  nfwa_version <- tryCatch(as.character(packageVersion("nfwa")), error = function(e) "dev")
+  cat("- R package versie: nfwa", nfwa_version, "\n")
 }
 ```


### PR DESCRIPTION
Closes #34

## Changes

**`R/run_models.R`**: `as.numeric()` on an already-factor `retentie` returns internal integer codes (1, 2), not label values. Both map to class `"1"`, leaving `"0"` with 0 observations and causing glmnet to abort. Fixed by routing through `as.character()` first.

**`inst/templates/render_pdf.qmd`**: `packageVersion("nfwa")` crashes in the Quarto subprocess when the package is dev-loaded rather than installed. Wrapped in `tryCatch` with a `"dev"` fallback.